### PR TITLE
Add feature-expense module

### DIFF
--- a/Android/src/feature-expense/build.gradle.kts
+++ b/Android/src/feature-expense/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    id("com.android.library")
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+}
+
+android {
+    namespace = "com.google.ai.edge.gallery.feature.expense"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 35
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+    implementation(libs.androidx.compose.navigation)
+
+    debugImplementation(libs.androidx.ui.tooling)
+}

--- a/Android/src/feature-expense/src/main/AndroidManifest.xml
+++ b/Android/src/feature-expense/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.google.ai.edge.gallery.feature.expense" />

--- a/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseNavGraph.kt
+++ b/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseNavGraph.kt
@@ -1,0 +1,10 @@
+package com.google.ai.edge.gallery.feature.expense
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+fun NavGraphBuilder.expenseGraph(navigateUp: () -> Unit) {
+    composable(route = ExpenseDestination.route) {
+        ExpenseScreen()
+    }
+}

--- a/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseScreen.kt
+++ b/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseScreen.kt
@@ -1,0 +1,17 @@
+package com.google.ai.edge.gallery.feature.expense
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.serialization.Serializable
+
+/** Navigation destination for the expense feature */
+object ExpenseDestination {
+    @Serializable
+    val route: String = "expense"
+}
+
+@Composable
+fun ExpenseScreen(modifier: Modifier = Modifier) {
+    Text(text = "Expense feature", modifier = modifier)
+}

--- a/Android/src/settings.gradle.kts
+++ b/Android/src/settings.gradle.kts
@@ -38,4 +38,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "AI Edge Gallery"
 include(":app")
+include(":feature-expense")
  


### PR DESCRIPTION
## Summary
- add a new Compose module `feature-expense`
- register the module in `settings.gradle.kts`

## Testing
- `./gradlew :feature-expense:tasks --no-daemon`
- `./gradlew :feature-expense:assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684983e466e8832195c438105fd09a18