### PR TITLE
Add feature-expense module

### DIFF
--- a/Android/src/feature-expense/build.gradle.kts
+++ b/Android/src/feature-expense/build.gradle.kts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("com.android.library")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+  namespace = "com.google.ai.edge.gallery.feature.expense"
+  compileSdk = 35
+
+  defaultConfig {
+    minSdk = 26
+    targetSdk = 35
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+
+  kotlinOptions {
+    jvmTarget = "11"
+  }
+
+  buildFeatures {
+    compose = true
+  }
+}
+
+dependencies {
+  implementation(platform(libs.androidx.compose.bom))
+  implementation(libs.androidx.ui)
+  implementation(libs.androidx.ui.graphics)
+  implementation(libs.androidx.ui.tooling.preview)
+  implementation(libs.androidx.material3)
+  implementation(libs.androidx.compose.navigation)
+  implementation(libs.kotlinx.serialization.json)
+
+  debugImplementation(libs.androidx.ui.tooling)
+}

--- a/Android/src/feature-expense/src/main/AndroidManifest.xml
+++ b/Android/src/feature-expense/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<manifest package="com.google.ai.edge.gallery.feature.expense" />

--- a/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseNavGraph.kt
+++ b/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseNavGraph.kt
@@ -14,30 +14,14 @@
  * limitations under the License.
  */
 
-pluginManagement {
-    repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-//        mavenLocal()
-        google()
-        mavenCentral()
-    }
+package com.google.ai.edge.gallery.feature.expense
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+fun NavGraphBuilder.expenseGraph(navigateUp: () -> Unit) {
+  composable(route = ExpenseDestination.route) {
+    ExpenseScreen()
+  }
 }
 
-rootProject.name = "AI Edge Gallery"
-include(":app")
-include(":feature-expense")
-
- 

--- a/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseScreen.kt
+++ b/Android/src/feature-expense/src/main/java/com/google/ai/edge/gallery/feature/expense/ExpenseScreen.kt
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-pluginManagement {
-    repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-//        mavenLocal()
-        google()
-        mavenCentral()
-    }
+package com.google.ai.edge.gallery.feature.expense
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.serialization.Serializable
+
+/** Navigation destination for the expense feature */
+object ExpenseDestination {
+  @Serializable
+  val route = "ExpenseRoute"
 }
 
-rootProject.name = "AI Edge Gallery"
-include(":app")
-include(":feature-expense")
+@Composable
+fun ExpenseScreen(modifier: Modifier = Modifier) {
+  Text(text = "Expense feature", modifier = modifier)
+}
 
- 


### PR DESCRIPTION
## Summary
- add a new Compose module `feature-expense`
- register the module in `settings.gradle.kts`
- apply code style fixes and license headers
- enable Kotlin serialization for the new module

## Testing
- `./gradlew :feature-expense:tasks --no-daemon`
- `./gradlew :feature-expense:assembleDebug --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_684983e466e8832195c438105fd09a18